### PR TITLE
Fix for missing "with" under Python 2.5

### DIFF
--- a/logan/settings.py
+++ b/logan/settings.py
@@ -7,6 +7,7 @@ logan.settings
 """
 
 from __future__ import absolute_import
+from __future__ import with_statement
 
 import errno
 import imp


### PR DESCRIPTION
Fix for this exception under Python 2.5:

``` python
Traceback (most recent call last):
  File "/opt/sentry/staging/bin/sentry", line 8, in <module>
    load_entry_point('sentry==4.0.16', 'console_scripts', 'sentry')()
  File "/opt/sentry/staging/lib/python2.5/site-packages/setuptools-0.6c11-py2.5.egg/pkg_resources.py", line 318, in load_entry_point
  File "/opt/sentry/staging/lib/python2.5/site-packages/setuptools-0.6c11-py2.5.egg/pkg_resources.py", line 2221, in load_entry_point
  File "/opt/sentry/staging/lib/python2.5/site-packages/setuptools-0.6c11-py2.5.egg/pkg_resources.py", line 1954, in load
  File "/opt/sentry/staging/lib/python2.5/site-packages/sentry-4.0.16-py2.5.egg/sentry/utils/runner.py", line 9, in <module>
    from logan.runner import run_app
  File "/opt/sentry/staging/lib/python2.5/site-packages/logan-0.2.1-py2.5.egg/logan/runner.py", line 18, in <module>
    from logan.settings import create_default_settings, load_settings, \
  File "/opt/sentry/staging/lib/python2.5/site-packages/logan-0.2.1-py2.5.egg/logan/settings.py", line 29
    with open(filepath, 'w') as fp:
            ^
SyntaxError: invalid syntax
```
