### PR TITLE
Fix settings double import problem

### DIFF
--- a/logan/runner.py
+++ b/logan/runner.py
@@ -121,6 +121,8 @@ def run_app(project=None, default_config_path=None, default_settings=None,
 
     if default_settings:
         settings_mod = import_module(default_settings)
+        from django.conf import settings, Settings
+        settings._wrapped = Settings(default_settings)
         # TODO: logan should create a proxy module for its settings
         management.setup_environ(settings_mod)
         add_settings(settings_mod)


### PR DESCRIPTION
After importing settings module in `run_app`, do some Django voodoo to let it know that the module was already imported, so it doesn't get imported again when we process settings.

This seems to fix https://github.com/dcramer/sentry/issues/445
